### PR TITLE
truncated and outlier removed spectral.psd, value checking in spectral.rotate_powerlaw

### DIFF
--- a/neurodsp/sim.py
+++ b/neurodsp/sim.py
@@ -762,5 +762,5 @@ def sim_variable_powerlaw(T, Fs, exponent):
     f_axis = np.fft.fftfreq(len(x), 1. / Fs)
 
     # rotate spectrum and invert, zscore to normalize
-    FC_rot = spectral.rotate_powerlaw(FC, f_axis, exponent/2., f_rotation=0)
+    FC_rot = spectral.rotate_powerlaw(f_axis, FC, exponent/2., f_rotation=None)
     return sp.stats.zscore(np.real(np.fft.ifft(FC_rot)))

--- a/neurodsp/spectral.py
+++ b/neurodsp/spectral.py
@@ -507,37 +507,3 @@ def rotate_powerlaw(psd, f_axis, delta_f, f_rotation=30):
 
     # apply mask
     return psd * f_mask
-
-# def rotate_powerlaw(spectrum, f_axis, delta_f, f_rotation=30):
-#     """Takes a PSD and changes its power law exponent about a given axis (frequency).
-#
-#     Parameters
-#     ----------
-#     spectrum : array, 1-D
-#         Power spectrum to be rotated.
-#     f_axis : array, 1-D, Hz
-#         Frequency axis of input spectrum. Must be same dimension as spectrum.
-#     delta_f : float
-#         Change in power law exponent to be applied. Positive is counterclockwise
-#         rotation (flatten), negative is clockwise rotation (steepen).
-#     f_rotation : float, Hz
-#         Axis of rotation frequency, such that power at that frequency is unchanged
-#         by the rotation. Only matters if not further normalizing signal variance.
-#
-#     Returns
-#     -------
-#     x : array, 1-D
-#         Rotated spectrum.
-#
-#     """
-#
-#     # make the 1/f rotation mask
-#     f_mask = np.zeros_like(f_axis)
-#     f_mask[1:] = 10**(np.log10(np.abs(f_axis[1:])) * (delta_f))
-#     f_mask[0] = 1.
-#
-#     # normalize power at rotation frequency
-#     f_mask = f_mask / f_mask[np.where(f_axis >= f_rotation)[0][0]]
-#
-#     # apply mask
-#     return spectrum * f_mask

--- a/neurodsp/spectral.py
+++ b/neurodsp/spectral.py
@@ -502,10 +502,10 @@ def rotate_powerlaw(psd, f_axis, delta_f, f_rotation=None):
 
     if f_rotation is not None:
         # normalize power at rotation frequency
-        f_mask = f_mask / f_mask[np.where(f_axis >= f_rotation)[0][0]]
-
         if np.all(f_rotation<np.abs(f_axis).min()) or np.all(f_rotation>np.abs(f_axis).max()):
             raise ValueError('Rotation frequency not within frequency range.')
+
+        f_mask = f_mask / f_mask[np.where(f_axis >= f_rotation)[0][0]]
 
     # apply mask
     return psd * f_mask

--- a/neurodsp/spectral.py
+++ b/neurodsp/spectral.py
@@ -502,7 +502,7 @@ def rotate_powerlaw(psd, f_axis, delta_f, f_rotation=None):
 
     if f_rotation is not None:
         # normalize power at rotation frequency
-        if np.all(f_rotation<np.abs(f_axis).min()) or np.all(f_rotation>np.abs(f_axis).max()):
+        if f_rotation<np.abs(f_axis).min() or f_rotation>np.abs(f_axis).max():
             raise ValueError('Rotation frequency not within frequency range.')
 
         f_mask = f_mask / f_mask[np.where(f_axis >= f_rotation)[0][0]]

--- a/neurodsp/spectral.py
+++ b/neurodsp/spectral.py
@@ -466,15 +466,15 @@ def morlet_convolve(x, f0, Fs, w=7, s=.5, M=None, norm='sss'):
     return mwt_real + 1j * mwt_imag
 
 
-def rotate_powerlaw(psd, f_axis, delta_f, f_rotation=None):
+def rotate_powerlaw(f_axis, psd, delta_f, f_rotation=None):
     """Change the power law exponent of a PSD about an axis frequency.
 
     Parameters
     ----------
+    f_axis : 1d array, Hz
+        Frequency axis of input PSD. Must be same length as psd.
     psd : 1d array
         Power spectrum to be rotated.
-    freqs : 1d array, Hz
-        Frequency axis of input PSD. Must be same length as psd.
     delta_f : float
         Change in power law exponent to be applied. Positive is counterclockwise
         rotation (flatten), negative is clockwise rotation (steepen).
@@ -485,7 +485,7 @@ def rotate_powerlaw(psd, f_axis, delta_f, f_rotation=None):
 
     Returns
     -------
-    x : 1d array
+    1d array
         Rotated psd.
 
     """
@@ -508,4 +508,4 @@ def rotate_powerlaw(psd, f_axis, delta_f, f_rotation=None):
         f_mask = f_mask / f_mask[np.where(f_axis >= f_rotation)[0][0]]
 
     # apply mask
-    return psd * f_mask
+    return f_mask * psd

--- a/neurodsp/spectral.py
+++ b/neurodsp/spectral.py
@@ -466,7 +466,7 @@ def morlet_convolve(x, f0, Fs, w=7, s=.5, M=None, norm='sss'):
     return mwt_real + 1j * mwt_imag
 
 
-def rotate_powerlaw(psd, f_axis, delta_f, f_rotation=30):
+def rotate_powerlaw(psd, f_axis, delta_f, f_rotation=None):
     """Change the power law exponent of a PSD about an axis frequency.
 
     Parameters
@@ -481,6 +481,7 @@ def rotate_powerlaw(psd, f_axis, delta_f, f_rotation=30):
     f_rotation : float, Hz, optional
         Axis of rotation frequency, such that power at that frequency is unchanged
         by the rotation. Only matters if not further normalizing signal variance.
+        If None, the transform normalizes to power at 1Hz by defaults.
 
     Returns
     -------
@@ -488,9 +489,6 @@ def rotate_powerlaw(psd, f_axis, delta_f, f_rotation=30):
         Rotated psd.
 
     """
-    if np.all(f_rotation<np.abs(f_axis).min()) or np.all(f_rotation>np.abs(f_axis).max()):
-        raise ValueError('Rotation frequency not within frequency range.')
-
     # make the 1/f rotation mask
     f_mask = np.zeros_like(f_axis)
     if f_axis[0] == 0.:
@@ -502,8 +500,12 @@ def rotate_powerlaw(psd, f_axis, delta_f, f_rotation=30):
         # Otherwise, apply rotation to all frequencies.
         f_mask = 10**(np.log10(np.abs(f_axis)) * (delta_f))
 
-    # normalize power at rotation frequency
-    f_mask = f_mask / f_mask[np.where(f_axis >= f_rotation)[0][0]]
+    if f_rotation is not None:
+        # normalize power at rotation frequency
+        f_mask = f_mask / f_mask[np.where(f_axis >= f_rotation)[0][0]]
+
+        if np.all(f_rotation<np.abs(f_axis).min()) or np.all(f_rotation>np.abs(f_axis).max()):
+            raise ValueError('Rotation frequency not within frequency range.')
 
     # apply mask
     return psd * f_mask

--- a/neurodsp/tests/test_spectral.py
+++ b/neurodsp/tests/test_spectral.py
@@ -107,7 +107,7 @@ def test_rotatepsd():
     rot_exp = -2
     P = np.ones(500)
     f_axis = np.arange(0,500.)
-    P_rot = neurodsp.spectral.rotate_powerlaw(P,f_axis,rot_exp,0)
+    P_rot = neurodsp.spectral.rotate_powerlaw(f_axis,P,rot_exp)
 
     # load test data PSDs for testing
     P_test = np.load(os.path.dirname(neurodsp.__file__) +


### PR DESCRIPTION
in spectral.psd():
- added flim option to return truncated psd
- added spg_outlierpct option to through out a percentage of spectrogram slices prior to averaging.

in spectral.rotate_powerlaw():
- check for whether f_axis[0] is 0Hz before defaulting to unity
- check that f_rotation is in range of f_axis