### PR TITLE
changed timefrequency functions to accept tuple with None for lowpass…

### DIFF
--- a/neurodsp/tests/test_timefreq.py
+++ b/neurodsp/tests/test_timefreq.py
@@ -41,10 +41,13 @@ def test_timefreq_consistent():
     i_f = freq_by_time(sig, fs, f_range)
 
     # Compute difference between current and past signals
-    assert np.allclose(np.sum(np.abs(pha[~np.isnan(pha)] - pha_true[~np.isnan(pha)])), 0, atol=10 ** -5)
-    assert np.allclose(np.sum(np.abs(amp[~np.isnan(amp)] - amp_true[~np.isnan(amp)])), 0, atol=10 ** -5)
+    assert np.allclose(
+        np.sum(np.abs(pha[~np.isnan(pha)] - pha_true[~np.isnan(pha)])), 0, atol=10 ** -5)
+    assert np.allclose(
+        np.sum(np.abs(amp[~np.isnan(amp)] - amp_true[~np.isnan(amp)])), 0, atol=10 ** -5)
     assert np.allclose(np.sum(np.abs(i_f[~np.isnan(i_f)] - i_f_true[~np.isnan(i_f_true)])),
                        0, atol=10 ** -5)
+
 
 def test_none_input():
     """
@@ -61,7 +64,7 @@ def test_none_input():
     phase_by_time(sig, fs, (None, fc))
     phase_by_time(sig, fs, (fc, None))
     amp_by_time(sig, fs, (None, fc))
-    amp_by_time(sig, fs, (fc ,None))
+    amp_by_time(sig, fs, (fc, None))
     assert True
 
 

--- a/neurodsp/tests/test_timefreq.py
+++ b/neurodsp/tests/test_timefreq.py
@@ -46,6 +46,24 @@ def test_timefreq_consistent():
     assert np.allclose(np.sum(np.abs(i_f[~np.isnan(i_f)] - i_f_true[~np.isnan(i_f_true)])),
                        0, atol=10 ** -5)
 
+def test_none_input():
+    """
+    Tests that passing (float, None) or (None, float) for highpass and lowpass
+    respectively will not result in error.
+    """
+    # Load data
+    data_idx = 1
+    sig = _load_example_data(data_idx=data_idx)
+    fs = 1000
+    fc = 20.5
+
+    # test that these run without error
+    phase_by_time(sig, fs, (None, fc))
+    phase_by_time(sig, fs, (fc, None))
+    amp_by_time(sig, fs, (None, fc))
+    amp_by_time(sig, fs, (fc ,None))
+    assert True
+
 
 def test_nan_in_x():
     """

--- a/neurodsp/timefrequency.py
+++ b/neurodsp/timefrequency.py
@@ -45,8 +45,10 @@ def phase_by_time(sig, fs, f_range, filter_kwargs=None,
     if filter_kwargs is None:
         filter_kwargs = {}
 
+    pass_type = _get_filt_passtype(f_range)
+
     # Filter signal
-    sig_filt, kernel = filter_signal(sig, fs, 'bandpass', fc=f_range,
+    sig_filt, kernel = filter_signal(sig, fs, pass_type, fc=f_range,
                                      remove_edge_artifacts=False,
                                      return_kernel=True,
                                      verbose=verbose, **filter_kwargs)
@@ -97,8 +99,10 @@ def amp_by_time(sig, fs, f_range, filter_kwargs=None,
     if filter_kwargs is None:
         filter_kwargs = {}
 
+    pass_type = _get_filt_passtype(f_range)
+
     # Filter signal
-    sig_filt, kernel = filter_signal(sig, fs, 'bandpass', fc=f_range,
+    sig_filt, kernel = filter_signal(sig, fs, pass_type, fc=f_range,
                                      remove_edge_artifacts=False,
                                      return_kernel=True,
                                      verbose=verbose, **filter_kwargs)
@@ -187,3 +191,19 @@ def _hilbert_ignore_nan(sig, hilbert_increase_n=False):
     sig_hilb[first_nonan:last_nonan] = sig_hilb_nonan
 
     return sig_hilb
+
+def _get_filt_passtype(f_range):
+    """
+    Given frequency range of filter, check for Nones to return appropriate
+        filter pass_type to filt.filter_signal.
+    """
+    if f_range[0] is None:
+        pass_type = 'lowpass'
+    elif f_range[1] is None:
+        pass_type = 'highpass'
+    else:
+        if f_range[0]>=f_range[1]:
+            raise ValueError('Second cutoff frequency must be greater than first.')
+        else:
+            pass_type = 'bandpass'
+    return pass_type

--- a/neurodsp/timefrequency.py
+++ b/neurodsp/timefrequency.py
@@ -11,6 +11,7 @@ from neurodsp.filt import filter_signal
 ###################################################################################################
 ###################################################################################################
 
+
 def phase_by_time(sig, fs, f_range, filter_kwargs=None,
                   hilbert_increase_n=False, remove_edge_artifacts=True,
                   verbose=True):
@@ -192,6 +193,7 @@ def _hilbert_ignore_nan(sig, hilbert_increase_n=False):
 
     return sig_hilb
 
+
 def _get_filt_passtype(f_range):
     """
     Given frequency range of filter, check for Nones to return appropriate
@@ -202,7 +204,7 @@ def _get_filt_passtype(f_range):
     elif f_range[1] is None:
         pass_type = 'highpass'
     else:
-        if f_range[0]>=f_range[1]:
+        if f_range[0] >= f_range[1]:
             raise ValueError('Second cutoff frequency must be greater than first.')
         else:
             pass_type = 'bandpass'


### PR DESCRIPTION
… or highpass as f_range

Because previously it's impossible to get amp_by_time, with the intention of just lowpassing, without an insanely long filter, since low-freq cutoff is required.